### PR TITLE
[PLT-3959] Fix CVE-2026-25679: Bump Go stdlib to 1.25.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.4.1 (upcoming)
+
+* [PLT-3959] Fix CVE-2026-25679: Bump Go stdlib from 1.25.3 to 1.25.8
+
 ### 0.4.0 (2026-02-25)
 
 * [PLT-3428] Bump oauth2 proxy upstream version to 7.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oauth2-proxy/oauth2-proxy/v7
 
-go 1.25.3
+go 1.25.8
 
 require (
 	cloud.google.com/go/compute/metadata v0.7.0


### PR DESCRIPTION
Upgrade Go version in go.mod from 1.25.3 to 1.25.8 to fix CVE-2026-25679 (net/url IPv6 parsing vulnerability, CVSS 7.5).

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
